### PR TITLE
Revert "Added timestamp header to aircraft truth (State message)"

### DIFF
--- a/fcu_sim_plugins/src/aircraft_truth.cpp
+++ b/fcu_sim_plugins/src/aircraft_truth.cpp
@@ -130,8 +130,6 @@ void AircraftTruth::PublishTruth()
   msg.quat[1] = v;
   msg.quat[2] = w;
 
-  msg.header.stamp.fromSec(world_->GetSimTime().Double());
-
   true_state_pub_.publish(msg);
 }
 


### PR DESCRIPTION
Reverts byu-magicc/fcu_sim#40

These changes cause problems in ros_plane that I didn't realize before. I would need to fix those problems first before keeping these merged changes.